### PR TITLE
feat: add get_contract method to riscv service

### DIFF
--- a/services/metadata/src/lib.rs
+++ b/services/metadata/src/lib.rs
@@ -12,7 +12,7 @@ use protocol::{ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 use crate::types::UpdateMetadataPayload;
 
-const ADMISSION_TOKEN: Bytes = Bytes::from_static(b"node_manager");
+static ADMISSION_TOKEN: Bytes = Bytes::from_static(b"node_manager");
 
 pub struct MetadataService<SDK> {
     sdk: SDK,
@@ -57,8 +57,7 @@ impl<SDK: ServiceSDK> MetadataService<SDK> {
                 metadata.precommit_ratio = payload.precommit_ratio;
                 metadata.prevote_ratio = payload.prevote_ratio;
                 metadata.propose_ratio = payload.propose_ratio;
-                self.sdk
-                    .set_value(METADATA_KEY.to_string(), metadata.clone())
+                self.sdk.set_value(METADATA_KEY.to_string(), metadata)
             } else {
                 Err(ServiceError::AdmissionFail.into())
             }

--- a/services/metadata/src/tests/mod.rs
+++ b/services/metadata/src/tests/mod.rs
@@ -17,13 +17,13 @@ use protocol::{types::Bytes, ProtocolResult};
 use crate::types::UpdateMetadataPayload;
 use crate::MetadataService;
 
-const ADMISSION_TOKEN: Bytes = Bytes::from_static(b"node_manager");
+static ADMISSION_TOKEN: Bytes = Bytes::from_static(b"node_manager");
 
 #[test]
 fn test_get_metadata() {
     let cycles_limit = 1024 * 1024 * 1024; // 1073741824
     let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
-    let context = mock_context(cycles_limit, caller.clone());
+    let context = mock_context(cycles_limit, caller);
 
     let init_metadata = mock_metadata_1();
 
@@ -37,7 +37,7 @@ fn test_get_metadata() {
 fn test_update_metadata() {
     let cycles_limit = 1024 * 1024 * 1024; // 1073741824
     let caller = Address::from_hex("0x755cdba6ae4f479f7164792b318b2a06c759833b").unwrap();
-    let context = mock_context(cycles_limit, caller.clone());
+    let context = mock_context(cycles_limit, caller);
 
     let init_metadata = mock_metadata_1();
     let mut service = new_metadata_service(init_metadata.clone());

--- a/services/node_manager/src/lib.rs
+++ b/services/node_manager/src/lib.rs
@@ -17,7 +17,7 @@ use crate::types::{
 };
 
 const ADMIN_KEY: &str = "admin";
-const ADMISSION_TOKEN: Bytes = Bytes::from_static(b"node_manager");
+static ADMISSION_TOKEN: Bytes = Bytes::from_static(b"node_manager");
 
 pub struct NodeManagerService<SDK> {
     sdk: SDK,

--- a/services/riscv/src/lib.rs
+++ b/services/riscv/src/lib.rs
@@ -14,7 +14,9 @@ use protocol::traits::ServiceSDK;
 use protocol::types::{Address, Hash, ServiceContext};
 use protocol::{Bytes, BytesMut, ProtocolError, ProtocolErrorKind, ProtocolResult};
 
-use crate::types::{Contract, DeployPayload, DeployResp, ExecPayload};
+use crate::types::{
+    Contract, DeployPayload, DeployResp, ExecPayload, GetContractPayload, GetContractResp,
+};
 use crate::vm::{ChainInterface, Interpreter, InterpreterConf, InterpreterParams};
 
 pub struct RiscvService<SDK> {
@@ -44,7 +46,7 @@ impl<SDK: ServiceSDK + 'static> RiscvService<SDK> {
             .sdk
             .borrow()
             .get_value::<Hash, Bytes>(&contract.code_hash)?
-            .unwrap();
+            .expect("get riscv contract code failed");
         let interpreter_params = InterpreterParams {
             address: payload.address.clone(),
             code,
@@ -131,6 +133,50 @@ impl<SDK: ServiceSDK + 'static> RiscvService<SDK> {
             address: contract_address,
             init_ret,
         })
+    }
+
+    #[read]
+    fn get_contract(
+        &self,
+        ctx: ServiceContext,
+        payload: GetContractPayload,
+    ) -> ProtocolResult<GetContractResp> {
+        ctx.sub_cycles(21000)?;
+        let contract = self
+            .sdk
+            .borrow()
+            .get_value::<Address, Contract>(&payload.address)?
+            .ok_or_else(|| ServiceError::ContractNotExists(payload.address.as_hex()))?;
+        let mut resp = GetContractResp {
+            code_hash: contract.code_hash.clone(),
+            intp_type: contract.intp_type,
+            ..Default::default()
+        };
+        if payload.get_code {
+            let code = self
+                .sdk
+                .borrow()
+                .get_value::<Hash, Bytes>(&contract.code_hash)?
+                .expect("get riscv contract code failed");
+            ctx.sub_cycles(code.len() as u64)?;
+            resp.code = hex::encode(&code);
+        }
+        for key in payload.storage_keys.iter() {
+            ctx.sub_cycles(key.len() as u64)?;
+            let decoded_key =
+                hex::decode(key).map_err(|_| ServiceError::InvalidKey(key.clone()))?;
+            let mut contract_key = BytesMut::from(payload.address.as_bytes().as_ref());
+            contract_key.extend(decoded_key);
+            let contract_key = Hash::digest(contract_key.freeze());
+            let value = self
+                .sdk
+                .borrow()
+                .get_value::<Hash, Bytes>(&contract_key)?
+                .unwrap_or_default();
+            ctx.sub_cycles(value.len() as u64)?;
+            resp.storage_values.push(hex::encode(value));
+        }
+        Ok(resp)
     }
 }
 
@@ -230,6 +276,9 @@ pub enum ServiceError {
 
     #[display(fmt = "hex decode error: {:?}", _0)]
     HexDecode(hex::FromHexError),
+
+    #[display(fmt = "invalid key '{:?}', should be a hex string", _0)]
+    InvalidKey(String),
 }
 
 impl std::error::Error for ServiceError {}

--- a/services/riscv/src/lib.rs
+++ b/services/riscv/src/lib.rs
@@ -46,7 +46,7 @@ impl<SDK: ServiceSDK + 'static> RiscvService<SDK> {
             .sdk
             .borrow()
             .get_value::<Hash, Bytes>(&contract.code_hash)?
-            .expect("get riscv contract code failed");
+            .ok_or_else(|| ServiceError::CodeNotFound)?;
         let interpreter_params = InterpreterParams {
             address: payload.address.clone(),
             code,
@@ -157,7 +157,7 @@ impl<SDK: ServiceSDK + 'static> RiscvService<SDK> {
                 .sdk
                 .borrow()
                 .get_value::<Hash, Bytes>(&contract.code_hash)?
-                .expect("get riscv contract code failed");
+                .ok_or_else(|| ServiceError::CodeNotFound)?;
             ctx.sub_cycles(code.len() as u64)?;
             resp.code = hex::encode(&code);
         }
@@ -264,6 +264,9 @@ pub enum ServiceError {
 
     #[display(fmt = "Contract {} not exists", _0)]
     ContractNotExists(String),
+
+    #[display(fmt = "code not found")]
+    CodeNotFound,
 
     #[display(fmt = "CKB VM return non zero, exitcode: {}, ret: {}", exitcode, ret)]
     NonZeroExitCode { exitcode: i8, ret: String },

--- a/services/riscv/src/tests/mod.rs
+++ b/services/riscv/src/tests/mod.rs
@@ -76,7 +76,6 @@ fn test_deploy_and_run() {
     let get_contract_resp = service
         .get_contract(context.clone(), get_contract_payload)
         .unwrap();
-    dbg!(&get_contract_resp);
     assert_eq!(&get_contract_resp.code, &code);
     assert_eq!(&get_contract_resp.storage_values, &vec![
         hex::encode("init"),

--- a/services/riscv/src/tests/mod.rs
+++ b/services/riscv/src/tests/mod.rs
@@ -16,7 +16,9 @@ use protocol::types::{
 };
 use protocol::{Bytes, ProtocolResult};
 
-use crate::types::{DeployPayload, ExecPayload, InterpreterType};
+use crate::types::{
+    DeployPayload, ExecPayload, GetContractPayload, GetContractResp, InterpreterType,
+};
 use crate::RiscvService;
 
 type TestRiscvService = RiscvService<
@@ -57,15 +59,33 @@ fn test_deploy_and_run() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
     let buffer = Bytes::from(buffer);
+    let code = hex::encode(buffer.as_ref());
     let deploy_payload = DeployPayload {
-        code:      hex::encode(buffer.as_ref()),
+        code:      code.clone(),
         intp_type: InterpreterType::Binary,
         init_args: "set k init".into(),
     };
     let deploy_result = service.deploy(context.clone(), deploy_payload).unwrap();
     assert_eq!(&deploy_result.init_ret, "");
-
     let address = deploy_result.address;
+
+    // test get_contract
+    let get_contract_payload = GetContractPayload {
+        address,
+        get_code: true,
+        storage_keys: vec![hex::encode("k"), "".to_owned(), "3a".to_owned()],
+    };
+    let get_contract_resp = service
+        .get_contract(context.clone(), get_contract_payload)
+        .unwrap();
+    dbg!(&get_contract_resp);
+    assert_eq!(&get_contract_resp.code, &code);
+    assert_eq!(&get_contract_resp.storage_values, &vec![
+        hex::encode("init"),
+        "".to_owned(),
+        "".to_owned()
+    ]);
+
     let exec_result = service.call(context.clone(), ExecPayload {
         address: address.clone(),
         args:    "get k".into(),

--- a/services/riscv/src/tests/mod.rs
+++ b/services/riscv/src/tests/mod.rs
@@ -16,9 +16,7 @@ use protocol::types::{
 };
 use protocol::{Bytes, ProtocolResult};
 
-use crate::types::{
-    DeployPayload, ExecPayload, GetContractPayload, GetContractResp, InterpreterType,
-};
+use crate::types::{DeployPayload, ExecPayload, GetContractPayload, InterpreterType};
 use crate::RiscvService;
 
 type TestRiscvService = RiscvService<
@@ -71,8 +69,8 @@ fn test_deploy_and_run() {
 
     // test get_contract
     let get_contract_payload = GetContractPayload {
-        address,
-        get_code: true,
+        address:      address.clone(),
+        get_code:     true,
         storage_keys: vec![hex::encode("k"), "".to_owned(), "3a".to_owned()],
     };
     let get_contract_resp = service

--- a/services/riscv/src/types.rs
+++ b/services/riscv/src/types.rs
@@ -30,9 +30,16 @@ impl TryFrom<u8> for InterpreterType {
     }
 }
 
+impl Default for InterpreterType {
+    fn default() -> Self {
+        Self::Binary
+    }
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct DeployPayload {
     pub code:      String,
+    #[serde(default)]
     pub intp_type: InterpreterType,
     pub init_args: String,
 }
@@ -66,6 +73,23 @@ pub struct InterpreterResult {
 pub struct Contract {
     pub code_hash: Hash,
     pub intp_type: InterpreterType,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct GetContractPayload {
+    pub address:      Address,
+    #[serde(default)]
+    pub get_code:     bool,
+    #[serde(default)]
+    pub storage_keys: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+pub struct GetContractResp {
+    pub code_hash:      Hash,
+    pub intp_type:      InterpreterType,
+    pub code:           String,
+    pub storage_values: Vec<String>,
 }
 
 impl FixedCodec for Contract {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
New Feature.

**What this PR does / why we need it**:
To make the riscv service have similar methods like `getCode` and `getStorageAt` in ethereum.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
